### PR TITLE
fix: Rewrite .md links to .html in HTML build output

### DIFF
--- a/scripts/md-to-html.ts
+++ b/scripts/md-to-html.ts
@@ -19,6 +19,20 @@ function buildMarkdown(): MarkdownIt {
 
   md.use(anchor, { permalink: false, slugify: (s: string) => s.trim().toLowerCase().replace(/\s+/g, "-").replace(/[^\p{L}\p{N}\-]/gu, "") });
   md.use(footnote);
+
+  const defaultLinkOpen = md.renderer.rules.link_open ?? ((tokens, idx, options, _env, self) => self.renderToken(tokens, idx, options));
+  md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+    const token = tokens[idx];
+    const hrefIndex = token.attrIndex("href");
+    if (hrefIndex >= 0) {
+      const href = token.attrs![hrefIndex][1];
+      if (/\.md(#.*)?$/.test(href)) {
+        token.attrs![hrefIndex][1] = href.replace(/\.md(#.*)?$/, (_m, hash) => `.html${hash ?? ""}`);
+      }
+    }
+    return defaultLinkOpen(tokens, idx, options, env, self);
+  };
+
   md.use(texmath, {
     engine: katex,
     delimiters: "dollars",


### PR DESCRIPTION
## Summary

- When Markdown files are converted to HTML via `npm run build`, internal links like `[Next →](chapter-1.md)` were left as-is, pointing to `.md` files that don't exist in the `dist/` directory — causing broken navigation in the browser.
- Added a custom `link_open` renderer rule in `buildMarkdown()` that rewrites any `href` ending in `.md` (including anchor fragments like `chapter-1.md#section`) to the corresponding `.html` path.
- Source `.md` files are **not modified** — links remain as `.md` in the source so they continue to work correctly in VS Code preview and on GitHub.

## Behavior

| Context | Link target | Works? |
| :--- | :--- | :--- |
| Source `.md` / GitHub / VS Code | `chapter-1.md` | ✅ |
| Built HTML in `dist/` | `chapter-1.html` (rewritten) | ✅ |

## Test plan

- [ ] Run `npm run build:all` and open `dist/chapter-0.html` in a browser
- [ ] Confirm "次へ" navigation links resolve correctly to the next chapter
- [ ] Confirm anchor fragment links (e.g. `chapter-1.md#section`) also rewrite correctly
- [ ] Confirm external URLs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)